### PR TITLE
fix: initialize color mode on client

### DIFF
--- a/src/app/(site)/hooks/useColorMode.ts
+++ b/src/app/(site)/hooks/useColorMode.ts
@@ -27,16 +27,24 @@ const ColorModeContext = createContext<ColorModeContextValue | undefined>(
 
 // Provider handling system preference, localStorage, and change events.
 export const ColorModeProvider = ({ children }: { children: ReactNode }) => {
-  const [mode, setMode] = useState<PaletteMode>(() => {
-    if (typeof window === "undefined") return "light";
+  const [mode, setMode] = useState<PaletteMode>("light");
+
+  // On mount read saved preference or system setting.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
     const stored = window.localStorage.getItem(
       STORAGE_KEY,
     ) as PaletteMode | null;
-    if (stored) return stored;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-  });
+    const preferred =
+      stored ??
+      (window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light");
+    setMode(preferred);
+    const root = document.documentElement;
+    root.classList.remove(preferred === "light" ? "dark" : "light");
+    root.classList.add(preferred);
+  }, []);
 
   // Persist to localStorage and update html class for Tailwind dark mode.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default color mode state to light without touching `window`
- hydrate mode from `localStorage` or system preference on mount
- separate persistence and event listener effects with cleanup

## Testing
- `npm run format:check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e2270d7ec8323ac67bf552582dd96