### PR TITLE
feat: add emotion insertion point for MUI styles

### DIFF
--- a/src/app/(site)/components/ThemeRegistry.tsx
+++ b/src/app/(site)/components/ThemeRegistry.tsx
@@ -19,7 +19,19 @@ interface Props {
 const ThemeInner = ({ children }: Props) => {
   const { mode } = useColorMode();
   const theme = useMemo(() => createAppTheme(mode), [mode]);
-  const cache = useMemo(() => createCache({ key: "mui", prepend: true }), []);
+  const cache = useMemo(() => {
+    const emotionInsertionPoint =
+      typeof document !== "undefined"
+        ? (document.querySelector(
+            "meta[name='emotion-insertion-point']",
+          ) as HTMLElement | null)
+        : null;
+
+    return createCache({
+      key: "mui",
+      insertionPoint: emotionInsertionPoint ?? undefined,
+    });
+  }, []);
 
   return (
     <CacheProvider value={cache}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,9 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="emotion-insertion-point" />
+      </head>
       {/* ThemeRegistry handles MUI theme and color mode */}
       <body className="min-h-screen flex flex-col">
         <ThemeRegistry>


### PR DESCRIPTION
## Summary
- insert emotion insertion point meta tag into root layout
- configure ThemeRegistry to use meta tag as Emotion cache insertion point

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e2276fac08323b97ab09020a931c9