### PR TITLE
test: expand color mode coverage

### DIFF
--- a/__tests__/useColorMode.test.tsx
+++ b/__tests__/useColorMode.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import {
   ColorModeProvider,
   useColorMode,
@@ -6,23 +6,26 @@ import {
 import React from "react";
 
 describe("useColorMode", () => {
-  beforeEach(() => {
-    // Mock matchMedia for jsdom environment
+  const setupMatchMedia = (matches: boolean) => {
     window.matchMedia = jest.fn().mockImplementation(() => ({
-      matches: false,
+      matches,
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
     })) as any;
+  };
+
+  beforeEach(() => {
+    setupMatchMedia(false);
     window.localStorage.clear();
   });
 
-  it("toggles between light and dark", () => {
+  it("toggles between light and dark and persists to localStorage", async () => {
     const TestComponent = () => {
       const { mode, toggle } = useColorMode();
       return <button onClick={toggle}>{mode}</button>;
     };
 
-    const { getByRole } = render(
+    const { getByRole, unmount } = render(
       <ColorModeProvider>
         <TestComponent />
       </ColorModeProvider>,
@@ -31,6 +34,35 @@ describe("useColorMode", () => {
     const button = getByRole("button");
     expect(button.textContent).toBe("light");
     fireEvent.click(button);
-    expect(button.textContent).toBe("dark");
+    await waitFor(() => expect(button.textContent).toBe("dark"));
+    expect(window.localStorage.getItem("color-mode")).toBe("dark");
+
+    unmount();
+
+    const { getByRole: getByRole2 } = render(
+      <ColorModeProvider>
+        <TestComponent />
+      </ColorModeProvider>,
+    );
+
+    const button2 = getByRole2("button");
+    await waitFor(() => expect(button2.textContent).toBe("dark"));
+  });
+
+  it("uses system preference on first load", async () => {
+    setupMatchMedia(true);
+
+    const TestComponent = () => {
+      const { mode } = useColorMode();
+      return <span>{mode}</span>;
+    };
+
+    const { getByText } = render(
+      <ColorModeProvider>
+        <TestComponent />
+      </ColorModeProvider>,
+    );
+
+    await waitFor(() => expect(getByText("dark")).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary
- wait for color mode effect before asserting final mode
- cover system preference detection
- verify localStorage persistence across mounts

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e227ab28883238c5bcbc923c0095b