### PR TITLE
fix: add emotion insertion point to root layout

### DIFF
--- a/__tests__/RootLayout.test.tsx
+++ b/__tests__/RootLayout.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import RootLayout from "../src/app/layout";
+
+describe("RootLayout", () => {
+  it("includes emotion insertion point in head", () => {
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })) as any;
+
+    render(
+      <RootLayout>
+        <div />
+      </RootLayout>,
+    );
+    const meta = document.head.querySelector(
+      'meta[name="emotion-insertion-point"]',
+    );
+    expect(meta).not.toBeNull();
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,9 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="emotion-insertion-point" content="" />
+      </head>
       {/* ThemeRegistry handles MUI theme and color mode */}
       <body className="min-h-screen flex flex-col">
         <ThemeRegistry>


### PR DESCRIPTION
## Summary
- ensure root layout defines `<head>` with emotion insertion point
- add test covering insertion point

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npx -y lighthouse https://example.com --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_689e227d76808323bd665f6c7244510f