### PR TITLE
fix: initialize emotion cache on mount

### DIFF
--- a/src/app/(site)/components/ThemeRegistry.tsx
+++ b/src/app/(site)/components/ThemeRegistry.tsx
@@ -3,8 +3,9 @@
 
 "use client";
 
-import { ReactNode, useMemo } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import createCache from "@emotion/cache";
+import type { EmotionCache } from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { StyledEngineProvider } from "@mui/material/styles";
@@ -19,19 +20,18 @@ interface Props {
 const ThemeInner = ({ children }: Props) => {
   const { mode } = useColorMode();
   const theme = useMemo(() => createAppTheme(mode), [mode]);
-  const cache = useMemo(() => {
-    const emotionInsertionPoint =
-      typeof document !== "undefined"
-        ? (document.querySelector(
-            "meta[name='emotion-insertion-point']",
-          ) as HTMLElement | null)
-        : null;
+  const [cache, setCache] = useState<EmotionCache | null>(null);
 
-    return createCache({
-      key: "mui",
-      insertionPoint: emotionInsertionPoint ?? undefined,
-    });
+  useEffect(() => {
+    const meta = document.querySelector<HTMLMetaElement>(
+      "meta[name='emotion-insertion-point']",
+    );
+    setCache(createCache({ key: "mui", insertionPoint: meta ?? undefined }));
   }, []);
+
+  if (!cache) {
+    return null;
+  }
 
   return (
     <CacheProvider value={cache}>


### PR DESCRIPTION
## Summary
- build Emotion cache after mount with useEffect
- avoid rendering until cache ready

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c289d1c8323b6a3d6b93ded2ffd