### PR TITLE
feat: add paper page with pdf viewer and share links

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -72,7 +72,7 @@ Be deployable on Vercel with minimal setup.
 
     Deliverables: src/app/page.tsx
 
-4) Paper Page
+4) Paper Page (Completed)
 
     Add src/public/paper.pdf placeholder; render with:
 

--- a/__tests__/PaperPage.test.tsx
+++ b/__tests__/PaperPage.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+import PaperPage from "../src/app/paper/page";
+
+describe("PaperPage", () => {
+  it("renders PDF viewer and download button", () => {
+    // Call component as function to ensure coverage of declaration
+    expect(PaperPage()).toBeTruthy();
+    render(<PaperPage />);
+    const pdf = screen.getByTestId("pdf-viewer");
+    expect(pdf).toBeInTheDocument();
+    const downloadLinks = screen.getAllByRole("link", {
+      name: /download pdf/i,
+    });
+    expect(downloadLinks[0]).toHaveAttribute("href", "/paper.pdf");
+    expect(downloadLinks[0]).toHaveAttribute("download");
+  });
+
+  it("renders outline links", () => {
+    render(<PaperPage />);
+    const outline = screen.getByTestId("outline");
+    expect(
+      within(outline).getByRole("link", { name: /resources/i }),
+    ).toHaveAttribute("href", "/resources");
+  });
+
+  it("shows citation block", () => {
+    render(<PaperPage />);
+    expect(screen.getByText(/cite this work/i)).toBeInTheDocument();
+  });
+
+  it("shows share buttons", () => {
+    render(<PaperPage />);
+    const share = screen.getByTestId("share-buttons");
+    expect(
+      within(share).getByRole("link", { name: /twitter/i }),
+    ).toHaveAttribute("href", expect.stringContaining("twitter"));
+    expect(
+      within(share).getByRole("link", { name: /linkedin/i }),
+    ).toHaveAttribute("href", expect.stringContaining("linkedin"));
+  });
+});

--- a/e2e/paper.spec.ts
+++ b/e2e/paper.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test("paper page displays viewer and download link", async ({ page }) => {
+  await page.goto("/paper");
+  await expect(page.getByTestId("pdf-viewer")).toBeVisible();
+  const download = page.getByRole("link", { name: /download pdf/i });
+  await expect(download).toHaveAttribute("href", "/paper.pdf");
+});

--- a/public/paper.pdf
+++ b/public/paper.pdf
@@ -1,0 +1,20 @@
+%PDF-1.4
+1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj
+2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj
+3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>endobj
+4 0 obj<< /Length 55 >>stream
+BT /F1 24 Tf 72 120 Td (Placeholder) Tj ET
+endstream endobj
+5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000117 00000 n 
+0000000264 00000 n 
+0000000360 00000 n 
+trailer<< /Size 6 /Root 1 0 R >>
+startxref
+425
+%%EOF

--- a/src/app/(site)/components/TrustSection.tsx
+++ b/src/app/(site)/components/TrustSection.tsx
@@ -4,13 +4,14 @@ import NextLink from "next/link";
 import { Box, Typography, Link as MUILink } from "@mui/material";
 
 export const TrustSection = () => (
-  <Box component="section" className="py-16 text-center center justify-items-center">
+  <Box
+    component="section"
+    className="py-16 text-center center justify-items-center"
+  >
     <Typography variant="h4" className="mb-4 font-semibold">
       We publish openly and put child safety before hype.
     </Typography>
-    <Typography
-      className="block mx-auto max-w-3xl text-center "
-    >
+    <Typography className="block mx-auto max-w-3xl text-center ">
       Our work translates complex AI frameworks into clear, role-specific
       steps—and every post invites transparency, dialogue, and peer review.
       Explore more on the{" "}
@@ -19,6 +20,5 @@ export const TrustSection = () => (
       </MUILink>
       .
     </Typography>
-
   </Box>
 );

--- a/src/app/paper/page.tsx
+++ b/src/app/paper/page.tsx
@@ -1,0 +1,87 @@
+import NextLink from "next/link";
+import { Box, Button, Link, Typography } from "@mui/material";
+
+/**
+ * PaperPage renders the research paper with auxiliary information.
+ *
+ * The component embeds a PDF viewer, provides a direct download link,
+ * surfaces related resources, offers citation text, and exposes simple
+ * share links. All elements are annotated for testing and clarity.
+ */
+export default function PaperPage() {
+  // Path to the PDF stored in the public folder
+  const pdfPath = "/paper.pdf";
+  // Placeholder citation text displayed in the citation block
+  const citationText = "Doe, J. (2024). AI Safety Paper. Windrose Publishing.";
+  // Static URL used for social shares; adjust in production for accuracy
+  const shareUrl = "https://example.com/paper";
+
+  return (
+    <Box component="main" id="content" className="flex flex-col gap-8 p-4">
+      {/* Inline PDF viewer */}
+      <Box className="h-[80vh] w-full" data-testid="pdf-viewer">
+        <object
+          data={pdfPath}
+          type="application/pdf"
+          className="h-full w-full"
+        />
+      </Box>
+
+      {/* Primary download button */}
+      <Button
+        component={Link}
+        href={pdfPath}
+        download
+        variant="contained"
+        className="self-start"
+      >
+        Download PDF
+      </Button>
+
+      {/* Outline linking to related site sections */}
+      <Box component="nav" data-testid="outline">
+        <Typography variant="h5" className="mb-2 font-semibold">
+          Related Content
+        </Typography>
+        <ul className="list-disc pl-5">
+          <li>
+            <Link component={NextLink} href="/resources">
+              Resources
+            </Link>
+          </li>
+          <li>
+            <Link component={NextLink} href="/blog">
+              Blog
+            </Link>
+          </li>
+        </ul>
+      </Box>
+
+      {/* Citation block for academic referencing */}
+      <Box component="section" className="border-l-4 border-gray-400 pl-4">
+        <Typography variant="h6" className="mb-1 font-semibold">
+          Cite this work
+        </Typography>
+        <Typography>{citationText}</Typography>
+      </Box>
+
+      {/* Simple share buttons without tracking */}
+      <Box data-testid="share-buttons" className="flex gap-4">
+        <Link
+          href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Twitter
+        </Link>
+        <Link
+          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          LinkedIn
+        </Link>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add research Paper page with inline PDF viewer, downloads, outline, citation, and share links
- cover Paper page with unit and e2e tests
- document project plan stage completion

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test -- --coverage`
- `npm run build`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*
- `npx lighthouse http://localhost:3000/paper --quiet --chrome-flags="--headless" --output=json --output-path=lighthouse-report.json` *(fails: CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_689e40d2c78c8323aa56e7cbc7564d27