### PR TITLE
feat: add resources page

### DIFF
--- a/__tests__/ResourceDetailPages.test.tsx
+++ b/__tests__/ResourceDetailPages.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import HomeChecklistPage from "@/app/resources/home-ai-safety-checklist/page";
+import SchoolMatrixPage from "@/app/resources/school-readiness-matrix/page";
+import SwotPage from "@/app/resources/swot-analysis/page";
+
+describe("Resource detail pages", () => {
+  const cases = [
+    {
+      Component: HomeChecklistPage,
+      title: "Home AI Safety Checklist",
+      pdf: "/resources/home-ai-safety-checklist.pdf",
+    },
+    {
+      Component: SchoolMatrixPage,
+      title: "School Readiness Matrix",
+      pdf: "/resources/school-readiness-matrix.pdf",
+    },
+    {
+      Component: SwotPage,
+      title: "AI Safety SWOT Analysis",
+      pdf: "/resources/swot-analysis.pdf",
+    },
+  ];
+  cases.forEach(({ Component, title, pdf }) => {
+    it(`renders ${title} page with download link`, () => {
+      render(<Component />);
+      expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: `Download ${title}` });
+      expect(link).toHaveAttribute("href", pdf);
+    });
+  });
+});

--- a/__tests__/ResourcesPage.test.tsx
+++ b/__tests__/ResourcesPage.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import ResourcesPage from "@/app/resources/page";
+
+describe("ResourcesPage", () => {
+  it("displays resource cards with download links", () => {
+    render(<ResourcesPage />);
+    const resources = [
+      {
+        title: "Home AI Safety Checklist",
+        href: "/resources/home-ai-safety-checklist",
+      },
+      {
+        title: "School Readiness Matrix",
+        href: "/resources/school-readiness-matrix",
+      },
+      { title: "AI Safety SWOT Analysis", href: "/resources/swot-analysis" },
+    ];
+    resources.forEach((r) => {
+      expect(
+        screen.getByRole("heading", { name: r.title }),
+      ).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: `Download ${r.title}` });
+      expect(link).toHaveAttribute("href", r.href);
+    });
+  });
+});

--- a/public/resources/home-ai-safety-checklist.pdf
+++ b/public/resources/home-ai-safety-checklist.pdf
@@ -1,0 +1,4 @@
+%PDF-1.4
+1 0 obj <<>> endobj
+trailer <<>>
+%%EOF

--- a/public/resources/school-readiness-matrix.pdf
+++ b/public/resources/school-readiness-matrix.pdf
@@ -1,0 +1,4 @@
+%PDF-1.4
+1 0 obj <<>> endobj
+trailer <<>>
+%%EOF

--- a/public/resources/swot-analysis.pdf
+++ b/public/resources/swot-analysis.pdf
@@ -1,0 +1,4 @@
+%PDF-1.4
+1 0 obj <<>> endobj
+trailer <<>>
+%%EOF

--- a/src/app/resources/home-ai-safety-checklist/page.tsx
+++ b/src/app/resources/home-ai-safety-checklist/page.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Typography } from "@mui/material";
+import NextLink from "next/link";
+
+export default function HomeChecklistPage() {
+  return (
+    <Box component="main" id="content" className="flex flex-col gap-4 p-4">
+      <Typography variant="h4" className="font-semibold">
+        Home AI Safety Checklist
+      </Typography>
+      <Typography>
+        Download the checklist to evaluate your home&apos;s AI readiness.
+      </Typography>
+      <Button
+        component={NextLink}
+        href="/resources/home-ai-safety-checklist.pdf"
+        download
+        variant="contained"
+        aria-label="Download Home AI Safety Checklist"
+      >
+        Download
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,0 +1,64 @@
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  Button,
+  Typography,
+} from "@mui/material";
+import NextLink from "next/link";
+
+interface Resource {
+  title: string;
+  description: string;
+  href: string;
+}
+
+const resources: Resource[] = [
+  {
+    title: "Home AI Safety Checklist",
+    description: "Practical steps to secure your home.",
+    href: "/resources/home-ai-safety-checklist",
+  },
+  {
+    title: "School Readiness Matrix",
+    description: "Evaluate how prepared your school is for AI integration.",
+    href: "/resources/school-readiness-matrix",
+  },
+  {
+    title: "AI Safety SWOT Analysis",
+    description: "Assess strengths, weaknesses, opportunities, and threats.",
+    href: "/resources/swot-analysis",
+  },
+];
+
+export default function ResourcesPage() {
+  return (
+    <Box
+      component="main"
+      id="content"
+      className="grid gap-6 p-4 md:grid-cols-3"
+    >
+      {resources.map((r) => (
+        <Card key={r.title} className="flex flex-col justify-between">
+          <CardContent>
+            <Typography variant="h6" className="mb-2 font-semibold">
+              {r.title}
+            </Typography>
+            <Typography>{r.description}</Typography>
+          </CardContent>
+          <CardActions>
+            <Button
+              component={NextLink}
+              href={r.href}
+              variant="contained"
+              aria-label={`Download ${r.title}`}
+            >
+              Download
+            </Button>
+          </CardActions>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/src/app/resources/school-readiness-matrix/page.tsx
+++ b/src/app/resources/school-readiness-matrix/page.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Typography } from "@mui/material";
+import NextLink from "next/link";
+
+export default function SchoolMatrixPage() {
+  return (
+    <Box component="main" id="content" className="flex flex-col gap-4 p-4">
+      <Typography variant="h4" className="font-semibold">
+        School Readiness Matrix
+      </Typography>
+      <Typography>
+        Evaluate how prepared your school is for AI integration.
+      </Typography>
+      <Button
+        component={NextLink}
+        href="/resources/school-readiness-matrix.pdf"
+        download
+        variant="contained"
+        aria-label="Download School Readiness Matrix"
+      >
+        Download
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/resources/swot-analysis/page.tsx
+++ b/src/app/resources/swot-analysis/page.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Typography } from "@mui/material";
+import NextLink from "next/link";
+
+export default function SwotPage() {
+  return (
+    <Box component="main" id="content" className="flex flex-col gap-4 p-4">
+      <Typography variant="h4" className="font-semibold">
+        AI Safety SWOT Analysis
+      </Typography>
+      <Typography>
+        Assess strengths, weaknesses, opportunities, and threats.
+      </Typography>
+      <Button
+        component={NextLink}
+        href="/resources/swot-analysis.pdf"
+        download
+        variant="contained"
+        aria-label="Download AI Safety SWOT Analysis"
+      >
+        Download
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add resources landing page with cards linking to free downloads
- add detail pages and placeholder PDFs for safety resources
- add tests for resources listing and detail pages

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --coverage`
- `npm run test:e2e` *(fails: browser download blocked)*
- `npm run build`
- `npx -y lighthouse http://localhost:3000/resources --quiet --chrome-flags="--headless --no-sandbox" --output=json --output-path=/tmp/lh.json` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e49bf0e5883238695bb95cfd81fc9