### PR TITLE
feat: add book a call page

### DIFF
--- a/__tests__/BookACallPage.test.tsx
+++ b/__tests__/BookACallPage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import BookACallPage from "../src/app/book-a-call/page";
+
+describe("BookACallPage", () => {
+  it("renders iframe and fallback link", () => {
+    render(<BookACallPage />);
+    const iframe = screen.getByTestId("calendar-iframe");
+    expect(iframe).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /open it in a new tab/i });
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("calendar.google"),
+    );
+  });
+});

--- a/src/app/book-a-call/page.tsx
+++ b/src/app/book-a-call/page.tsx
@@ -1,0 +1,33 @@
+import { Box, Link, Typography } from "@mui/material";
+
+export default function BookACallPage() {
+  const calendarUrl = "https://calendar.google.com"; // placeholder; replace with actual link
+
+  return (
+    <Box
+      component="main"
+      id="content"
+      className="flex flex-col items-center gap-6 p-4 text-center"
+    >
+      <Typography variant="h4" className="font-semibold">
+        Book a Call
+      </Typography>
+      <Box className="w-full max-w-3xl">
+        <iframe
+          src={calendarUrl}
+          title="Book a Call"
+          className="h-[800px] w-full border-0"
+          data-testid="calendar-iframe"
+          allowFullScreen
+        />
+      </Box>
+      <Typography>
+        If the calendar does not load, {""}
+        <Link href={calendarUrl} target="_blank" rel="noopener noreferrer">
+          open it in a new tab
+        </Link>
+        .
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add Book a Call page with embedded Google Calendar and fallback link
- test Book a Call page rendering of iframe and fallback

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e96dcd5c083238907352c917bc642